### PR TITLE
Implement order inquiry functions

### DIFF
--- a/src/stock/order.rs
+++ b/src/stock/order.rs
@@ -153,11 +153,114 @@ impl Korea {
             .await?)
     }
 
-    // TODO: 주식정정취소가능주문조회[v1_국내주식-004]
-    // [Docs](https://apiportal.koreainvestment.com/apiservice/apiservice-domestic-stock#L_d4537e9c-73f7-414c-9fb0-4eae3bc397d0)
-
-    // TODO: 주식일별주문체결조회[v1_국내주식-005]
-    // [Docs](https://apiportal.koreainvestment.com/apiservice/apiservice-domestic-stock#L_bc51f9f7-146f-4971-a5ae-ebd574acec12)
+    /// 주식정정취소가능주문조회[v1_국내주식-004]
+    /// [Docs](https://apiportal.koreainvestment.com/apiservice/apiservice-domestic-stock#L_d4537e9c-73f7-414c-9fb0-4eae3bc397d0)
+    pub async fn inquire_psbl_rvsecncl(
+        &self,
+        inqr_dvsn_1: &str,
+        inqr_dvsn_2: &str,
+        ctx_area_fk100: Option<&str>,
+        ctx_area_nk100: Option<&str>,
+    ) -> Result<response::stock::order::Body::InquirePsblRvsecncl, Error> {
+        use crate::types::request::stock::order::Body::InquirePsblRvsecncl as Param;
+        let params = Param::new(
+            self.account.cano.clone(),
+            self.account.acnt_prdt_cd.clone(),
+            ctx_area_fk100.map(|s| s.to_string()),
+            ctx_area_nk100.map(|s| s.to_string()),
+            inqr_dvsn_1.to_string(),
+            inqr_dvsn_2.to_string(),
+        );
+        let tr_id = "TTTC0084R";
+        let token = match self.auth.get_token() {
+            Some(token) => format!("Bearer {}", token),
+            None => return Err(Error::AuthInitFailed("token")),
+        };
+        let mut req = self.client.get(format!(
+            "{}/uapi/domestic-stock/v1/trading/inquire-psbl-rvsecncl",
+            "https://openapi.koreainvestment.com:9443"
+        ));
+        req = req
+            .header("Content-Type", "application/json; charset=utf-8")
+            .header("Authorization", token)
+            .header("appkey", self.auth.get_appkey())
+            .header("appsecret", self.auth.get_appsecret())
+            .header("tr_id", tr_id)
+            .header("custtype", "P");
+        for (k, v) in params.into_iter() {
+            req = req.query(&[(k, v)]);
+        }
+        Ok(req
+            .send()
+            .await?
+            .json::<response::stock::order::Body::InquirePsblRvsecncl>()
+            .await?)
+    }
+    /// 주식일별주문체결조회[v1_국내주식-005]
+    /// [Docs](https://apiportal.koreainvestment.com/apiservice/apiservice-domestic-stock#L_bc51f9f7-146f-4971-a5ae-ebd574acec12)
+    #[allow(clippy::too_many_arguments)]
+    pub async fn inquire_daily_ccld(
+        &self,
+        inqr_strt_dt: &str,
+        inqr_end_dt: &str,
+        sll_buy_dvsn_cd: &str,
+        pdno: &str,
+        ord_gno_brno: &str,
+        odno: &str,
+        ccld_dvsn: &str,
+        inqr_dvsn: &str,
+        inqr_dvsn_1: &str,
+        inqr_dvsn_3: &str,
+        excg_id_dvsn_cd: &str,
+        ctx_area_fk100: Option<&str>,
+        ctx_area_nk100: Option<&str>,
+    ) -> Result<response::stock::order::Body::InquireDailyCcld, Error> {
+        use crate::types::request::stock::order::Body::InquireDailyCcld as Param;
+        let params = Param::new(
+            self.account.cano.clone(),
+            self.account.acnt_prdt_cd.clone(),
+            inqr_strt_dt.to_string(),
+            inqr_end_dt.to_string(),
+            sll_buy_dvsn_cd.to_string(),
+            pdno.to_string(),
+            ord_gno_brno.to_string(),
+            odno.to_string(),
+            ccld_dvsn.to_string(),
+            inqr_dvsn.to_string(),
+            inqr_dvsn_1.to_string(),
+            inqr_dvsn_3.to_string(),
+            excg_id_dvsn_cd.to_string(),
+            ctx_area_fk100.map(|s| s.to_string()),
+            ctx_area_nk100.map(|s| s.to_string()),
+        );
+        let tr_id = match self.environment {
+            Environment::Real => "TTTC0081R",
+            Environment::Virtual => "VTTC0081R",
+        };
+        let token = match self.auth.get_token() {
+            Some(token) => format!("Bearer {}", token),
+            None => return Err(Error::AuthInitFailed("token")),
+        };
+        let mut req = self.client.get(format!(
+            "{}/uapi/domestic-stock/v1/trading/inquire-daily-ccld",
+            self.endpoint_url
+        ));
+        req = req
+            .header("Content-Type", "application/json; charset=utf-8")
+            .header("Authorization", token)
+            .header("appkey", self.auth.get_appkey())
+            .header("appsecret", self.auth.get_appsecret())
+            .header("tr_id", tr_id)
+            .header("custtype", "P");
+        for (k, v) in params.into_iter() {
+            req = req.query(&[(k, v)]);
+        }
+        Ok(req
+            .send()
+            .await?
+            .json::<response::stock::order::Body::InquireDailyCcld>()
+            .await?)
+    }
 
     /// 주식잔고조회[v1_국내주식-006]
     /// [Docs](https://apiportal.koreainvestment.com/apiservice/apiservice-domestic-stock#L_66c61080-674f-4c91-a0cc-db5e64e9a5e6)

--- a/src/types/request/stock/order.rs
+++ b/src/types/request/stock/order.rs
@@ -205,4 +205,159 @@ pub mod Body {
             ]
         }
     }
+    /// 주식정정취소가능주문조회 Query Parameter
+    #[derive(Debug, Clone, Getters, Setters, Serialize)]
+    #[serde(rename_all = "UPPERCASE")]
+    pub struct InquirePsblRvsecncl {
+        #[getset(get = "pub", set = "pub")]
+        pub cano: String,
+        #[getset(get = "pub", set = "pub")]
+        pub acnt_prdt_cd: String,
+        #[getset(get = "pub", set = "pub")]
+        pub ctx_area_fk100: Option<String>,
+        #[getset(get = "pub", set = "pub")]
+        pub ctx_area_nk100: Option<String>,
+        #[getset(get = "pub", set = "pub")]
+        pub inqr_dvsn_1: String,
+        #[getset(get = "pub", set = "pub")]
+        pub inqr_dvsn_2: String,
+    }
+
+    impl InquirePsblRvsecncl {
+        pub fn new(
+            cano: String,
+            acnt_prdt_cd: String,
+            ctx_area_fk100: Option<String>,
+            ctx_area_nk100: Option<String>,
+            inqr_dvsn_1: String,
+            inqr_dvsn_2: String,
+        ) -> Self {
+            Self {
+                cano,
+                acnt_prdt_cd,
+                ctx_area_fk100,
+                ctx_area_nk100,
+                inqr_dvsn_1,
+                inqr_dvsn_2,
+            }
+        }
+
+        pub fn into_iter(&self) -> Vec<(&'static str, String)> {
+            vec![
+                ("CANO", self.cano.clone()),
+                ("ACNT_PRDT_CD", self.acnt_prdt_cd.clone()),
+                (
+                    "CTX_AREA_FK100",
+                    self.ctx_area_fk100.clone().unwrap_or_default(),
+                ),
+                (
+                    "CTX_AREA_NK100",
+                    self.ctx_area_nk100.clone().unwrap_or_default(),
+                ),
+                ("INQR_DVSN_1", self.inqr_dvsn_1.clone()),
+                ("INQR_DVSN_2", self.inqr_dvsn_2.clone()),
+            ]
+        }
+    }
+
+    /// 주식일별주문체결조회 Query Parameter
+    #[derive(Debug, Clone, Getters, Setters, Serialize)]
+    #[serde(rename_all = "UPPERCASE")]
+    pub struct InquireDailyCcld {
+        #[getset(get = "pub", set = "pub")]
+        pub cano: String,
+        #[getset(get = "pub", set = "pub")]
+        pub acnt_prdt_cd: String,
+        #[getset(get = "pub", set = "pub")]
+        pub inqr_strt_dt: String,
+        #[getset(get = "pub", set = "pub")]
+        pub inqr_end_dt: String,
+        #[getset(get = "pub", set = "pub")]
+        pub sll_buy_dvsn_cd: String,
+        #[getset(get = "pub", set = "pub")]
+        pub pdno: String,
+        #[getset(get = "pub", set = "pub")]
+        pub ord_gno_brno: String,
+        #[getset(get = "pub", set = "pub")]
+        pub odno: String,
+        #[getset(get = "pub", set = "pub")]
+        pub ccld_dvsn: String,
+        #[getset(get = "pub", set = "pub")]
+        pub inqr_dvsn: String,
+        #[getset(get = "pub", set = "pub")]
+        pub inqr_dvsn_1: String,
+        #[getset(get = "pub", set = "pub")]
+        pub inqr_dvsn_3: String,
+        #[getset(get = "pub", set = "pub")]
+        pub excg_id_dvsn_cd: String,
+        #[getset(get = "pub", set = "pub")]
+        pub ctx_area_fk100: Option<String>,
+        #[getset(get = "pub", set = "pub")]
+        pub ctx_area_nk100: Option<String>,
+    }
+
+    impl InquireDailyCcld {
+        #[allow(clippy::too_many_arguments)]
+        pub fn new(
+            cano: String,
+            acnt_prdt_cd: String,
+            inqr_strt_dt: String,
+            inqr_end_dt: String,
+            sll_buy_dvsn_cd: String,
+            pdno: String,
+            ord_gno_brno: String,
+            odno: String,
+            ccld_dvsn: String,
+            inqr_dvsn: String,
+            inqr_dvsn_1: String,
+            inqr_dvsn_3: String,
+            excg_id_dvsn_cd: String,
+            ctx_area_fk100: Option<String>,
+            ctx_area_nk100: Option<String>,
+        ) -> Self {
+            Self {
+                cano,
+                acnt_prdt_cd,
+                inqr_strt_dt,
+                inqr_end_dt,
+                sll_buy_dvsn_cd,
+                pdno,
+                ord_gno_brno,
+                odno,
+                ccld_dvsn,
+                inqr_dvsn,
+                inqr_dvsn_1,
+                inqr_dvsn_3,
+                excg_id_dvsn_cd,
+                ctx_area_fk100,
+                ctx_area_nk100,
+            }
+        }
+
+        pub fn into_iter(&self) -> Vec<(&'static str, String)> {
+            vec![
+                ("CANO", self.cano.clone()),
+                ("ACNT_PRDT_CD", self.acnt_prdt_cd.clone()),
+                ("INQR_STRT_DT", self.inqr_strt_dt.clone()),
+                ("INQR_END_DT", self.inqr_end_dt.clone()),
+                ("SLL_BUY_DVSN_CD", self.sll_buy_dvsn_cd.clone()),
+                ("PDNO", self.pdno.clone()),
+                ("ORD_GNO_BRNO", self.ord_gno_brno.clone()),
+                ("ODNO", self.odno.clone()),
+                ("CCLD_DVSN", self.ccld_dvsn.clone()),
+                ("INQR_DVSN", self.inqr_dvsn.clone()),
+                ("INQR_DVSN_1", self.inqr_dvsn_1.clone()),
+                ("INQR_DVSN_3", self.inqr_dvsn_3.clone()),
+                ("EXCG_ID_DVSN_CD", self.excg_id_dvsn_cd.clone()),
+                (
+                    "CTX_AREA_FK100",
+                    self.ctx_area_fk100.clone().unwrap_or_default(),
+                ),
+                (
+                    "CTX_AREA_NK100",
+                    self.ctx_area_nk100.clone().unwrap_or_default(),
+                ),
+            ]
+        }
+    }
 }

--- a/src/types/response/stock/order.rs
+++ b/src/types/response/stock/order.rs
@@ -78,6 +78,24 @@ pub mod Body {
         #[getset(get = "pub")]
         output: Output::InquirePsblOrder,
     }
+    /// 주식일별주문체결조회
+    #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, Getters)]
+    pub struct InquireDailyCcld {
+        #[getset(get = "pub")]
+        rt_cd: String,
+        #[getset(get = "pub")]
+        msg_cd: String,
+        #[getset(get = "pub")]
+        msg1: String,
+        #[getset(get = "pub")]
+        ctx_area_fk100: Option<String>,
+        #[getset(get = "pub")]
+        ctx_area_nk100: Option<String>,
+        #[getset(get = "pub")]
+        output1: Option<Vec<Output::InquireDailyCcld1>>,
+        #[getset(get = "pub")]
+        output2: Option<Output::InquireDailyCcld2>,
+    }
 }
 
 pub mod Output {
@@ -192,5 +210,94 @@ pub mod Output {
         /// 주문가능외화금액원화
         #[getset(get = "pub")]
         ord_psbl_frcr_amt_wcrc: String,
+    #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, Getters)]
+    pub struct InquireDailyCcld1 {
+        #[getset(get = "pub")]
+        ord_dt: String,
+        #[getset(get = "pub")]
+        ord_gno_brno: String,
+        #[getset(get = "pub")]
+        odno: String,
+        #[getset(get = "pub")]
+        orgn_odno: String,
+        #[getset(get = "pub")]
+        ord_dvsn_name: String,
+        #[getset(get = "pub")]
+        sll_buy_dvsn_cd: String,
+        #[getset(get = "pub")]
+        sll_buy_dvsn_cd_name: String,
+        #[getset(get = "pub")]
+        pdno: String,
+        #[getset(get = "pub")]
+        prdt_name: String,
+        #[getset(get = "pub")]
+        ord_qty: String,
+        #[getset(get = "pub")]
+        ord_unpr: String,
+        #[getset(get = "pub")]
+        ord_tmd: String,
+        #[getset(get = "pub")]
+        tot_ccld_qty: String,
+        #[getset(get = "pub")]
+        avg_prvs: String,
+        #[getset(get = "pub")]
+        cncl_yn: String,
+        #[getset(get = "pub")]
+        tot_ccld_amt: String,
+        #[getset(get = "pub")]
+        loan_dt: String,
+        #[getset(get = "pub")]
+        ordr_empno: String,
+        #[getset(get = "pub")]
+        ord_dvsn_cd: String,
+        #[getset(get = "pub")]
+        cnc_cfrm_qty: String,
+        #[getset(get = "pub")]
+        rmn_qty: String,
+        #[getset(get = "pub")]
+        rjct_qty: String,
+        #[getset(get = "pub")]
+        ccld_cndt_name: String,
+        #[getset(get = "pub")]
+        inqr_ip_addr: String,
+        #[getset(get = "pub")]
+        cpbc_ordp_ord_rcit_dvsn_cd: String,
+        #[getset(get = "pub")]
+        cpbc_ordp_infm_mthd_dvsn_cd: String,
+        #[getset(get = "pub")]
+        infm_tmd: String,
+        #[getset(get = "pub")]
+        ctac_tlno: String,
+        #[getset(get = "pub")]
+        prdt_type_cd: String,
+        #[getset(get = "pub")]
+        excg_dvsn_cd: String,
+        #[getset(get = "pub")]
+        cpbc_ordp_mtrl_dvsn_cd: String,
+        #[getset(get = "pub")]
+        ord_orgno: String,
+        #[getset(get = "pub")]
+        rsvn_ord_end_dt: String,
+        #[getset(get = "pub")]
+        excg_id_dvsn_Cd: String,
+        #[getset(get = "pub")]
+        stpm_cndt_pric: String,
+        #[getset(get = "pub")]
+        stpm_efct_occr_dtmd: String,
+    }
+
+    #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, Getters)]
+    pub struct InquireDailyCcld2 {
+        #[getset(get = "pub")]
+        tot_ord_qty: String,
+        #[getset(get = "pub")]
+        tot_ccld_qty: String,
+        #[getset(get = "pub")]
+        tot_ccld_amt: String,
+        #[getset(get = "pub")]
+        prsm_tlex_smtl: String,
+        #[getset(get = "pub")]
+        pchs_avg_pric: String,
+    }
     }
 }


### PR DESCRIPTION
## Summary
- implement `inquire_psbl_rvsecncl` and `inquire_daily_ccld` in `order.rs`
- support new request parameters for these APIs
- add response structs for daily order inquiry

## Testing
- `cargo fmt` *(fails: component download blocked)*
- `cargo check` *(fails: unable to download index.crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_68789c3c9d3c832c9efaaf6a8bb64043